### PR TITLE
Rewrote coroutines to be more like Boost coroutine2

### DIFF
--- a/include/gba/ext/agbabi/coroutine.hpp
+++ b/include/gba/ext/agbabi/coroutine.hpp
@@ -16,10 +16,10 @@
 
 namespace gba::agbabi {
 
-template <typename Type>
+template <typename T>
 struct coroutine {
-    using pull_type = pull_coroutine<Type>;
-    using push_type = push_coroutine<Type>;
+    using pull_type = pull_coroutine<T>;
+    using push_type = push_coroutine<T>;
 };
 
 template <>

--- a/include/gba/ext/agbabi/detail/coro_context.hpp
+++ b/include/gba/ext/agbabi/detail/coro_context.hpp
@@ -1,0 +1,57 @@
+/*
+===============================================================================
+
+ Copyright (C) 2022 gba-hpp contributors
+ For conditions of distribution and use, see copyright notice in LICENSE.md
+
+===============================================================================
+*/
+
+#ifndef GBAXX_EXT_AGBABI_DETAIL_CORO_HPP
+#define GBAXX_EXT_AGBABI_DETAIL_CORO_HPP
+
+#include <agbabi.h>
+
+namespace gba::agbabi::detail {
+
+    using coro_proc_type = int(*)(agbabi_coro_t*);
+
+    template <typename T>
+    struct context_type;
+
+    template <typename T>
+    struct coro_type : agbabi_coro_t {
+        context_type<T>* ctx;
+        T* value;
+    };
+
+    template <>
+    struct coro_type<void> : agbabi_coro_t {
+        context_type<void>* ctx;
+    };
+
+    template <typename T>
+    struct context_type {
+        context_type() noexcept = default;
+        explicit context_type(detail::coro_type<T>* co) noexcept : coro{co} {}
+
+        virtual ~context_type() noexcept = default;
+        virtual void swap() noexcept = 0;
+
+        detail::coro_type<T>* coro;
+    };
+
+    template <typename T>
+    struct yield_context_type : context_type<T> {
+        explicit yield_context_type(detail::coro_type<T>* co) noexcept : context_type<T>{co} {}
+
+        ~yield_context_type() noexcept override = default;
+
+        void swap() noexcept override {
+            __agbabi_coro_yield(context_type<T>::coro, 0);
+        }
+    };
+
+} // namespace gba::agbabi::detail
+
+#endif // define GBAXX_EXT_AGBABI_DETAIL_CORO_HPP

--- a/include/gba/ext/agbabi/detail/pull_coroutine_context.hpp
+++ b/include/gba/ext/agbabi/detail/pull_coroutine_context.hpp
@@ -1,0 +1,36 @@
+/*
+===============================================================================
+
+ Copyright (C) 2022 gba-hpp contributors
+ For conditions of distribution and use, see copyright notice in LICENSE.md
+
+===============================================================================
+*/
+
+#ifndef GBAXX_EXT_AGBABI_DETAIL_PULL_COROUTINE_CONTEXT_HPP
+#define GBAXX_EXT_AGBABI_DETAIL_PULL_COROUTINE_CONTEXT_HPP
+
+#include <agbabi.h>
+
+#include <gba/ext/agbabi/pull_coroutine.hpp>
+#include <gba/ext/agbabi/push_coroutine.hpp>
+
+#include <gba/ext/agbabi/detail/coro_context.hpp>
+
+namespace gba::agbabi {
+
+template <typename T>
+template <typename Fn>
+detail::coro_proc_type pull_coroutine<T>::callable_context_type<Fn>::get_invoke() noexcept {
+    return reinterpret_cast<detail::coro_proc_type>(+[](coro_type* coro) {
+        auto* ctx = reinterpret_cast<callable_context_type*>(coro->ctx);
+        auto y = detail::yield_context_type{coro};
+        auto f = push_coroutine<T>(&y);
+        ctx->m_fn(f);
+        return 0;
+    });
+}
+
+} // namespace gba::agbabi
+
+#endif // define GBAXX_EXT_AGBABI_DETAIL_PULL_COROUTINE_CONTEXT_HPP

--- a/include/gba/ext/agbabi/detail/push_coroutine_context.hpp
+++ b/include/gba/ext/agbabi/detail/push_coroutine_context.hpp
@@ -1,0 +1,36 @@
+/*
+===============================================================================
+
+ Copyright (C) 2022 gba-hpp contributors
+ For conditions of distribution and use, see copyright notice in LICENSE.md
+
+===============================================================================
+*/
+
+#ifndef GBAXX_EXT_AGBABI_DETAIL_PUSH_COROUTINE_CONTEXT_HPP
+#define GBAXX_EXT_AGBABI_DETAIL_PUSH_COROUTINE_CONTEXT_HPP
+
+#include <agbabi.h>
+
+#include <gba/ext/agbabi/pull_coroutine.hpp>
+#include <gba/ext/agbabi/push_coroutine.hpp>
+
+#include <gba/ext/agbabi/detail/coro_context.hpp>
+
+namespace gba::agbabi {
+
+template <typename T>
+template <typename Fn>
+detail::coro_proc_type push_coroutine<T>::callable_context_type<Fn>::get_invoke() noexcept {
+    return reinterpret_cast<detail::coro_proc_type>(+[](coro_type* coro) {
+        auto* ctx = reinterpret_cast<callable_context_type*>(coro->ctx);
+        auto y = detail::yield_context_type{coro};
+        auto f = pull_coroutine<T>(&y);
+        ctx->m_fn(f);
+        return 0;
+    });
+}
+
+} // namespace gba::agbabi
+
+#endif // define GBAXX_EXT_AGBABI_DETAIL_PUSH_COROUTINE_CONTEXT_HPP

--- a/include/gba/ext/agbabi/detail/stack.hpp
+++ b/include/gba/ext/agbabi/detail/stack.hpp
@@ -1,0 +1,64 @@
+/*
+===============================================================================
+
+ Copyright (C) 2022 gba-hpp contributors
+ For conditions of distribution and use, see copyright notice in LICENSE.md
+
+===============================================================================
+*/
+
+#ifndef GBAXX_EXT_AGBABI_DETAIL_STACK_HPP
+#define GBAXX_EXT_AGBABI_DETAIL_STACK_HPP
+
+#include <concepts>
+#include <cstdint>
+#include <utility>
+
+#include <agbabi.h>
+
+#include <gba/util/array_traits.hpp>
+
+namespace gba::agbabi::detail {
+
+    template <class T>
+    concept PointerEnd = requires(T& a) {
+        { std::end(a) } -> std::same_as<util::array_value_type<T>*>;
+    };
+
+    template <typename T>
+    auto* stack_reserve(void* stack) noexcept {
+        static constexpr auto aligned = ((sizeof(T) + 7u) >> 3u) << 3u;
+        auto pointer = (reinterpret_cast<std::uintptr_t>(stack) & ~0x7u) - aligned;
+
+        return reinterpret_cast<T*>(pointer);
+    }
+
+    template <typename T, typename... Args>
+    auto* stack_emplace(void* stack, Args&&... args) noexcept {
+        static constexpr auto aligned = ((sizeof(T) + 7u) >> 3u) << 3u;
+        auto pointer = (reinterpret_cast<std::uintptr_t>(stack) & ~0x7u) - aligned;
+
+        return new(reinterpret_cast<void*>(pointer)) T(std::forward<Args>(args)...);
+    }
+
+    template <typename T, typename... Ts>
+    auto* stack_push(void* stack, T&& first, Ts&&... rest) noexcept {
+        static constexpr auto aligned = ((sizeof(T) + 7u) >> 3u) << 3u;
+        auto pointer = (reinterpret_cast<std::uintptr_t>(stack) & ~0x7u) - aligned;
+
+        *reinterpret_cast<T*>(pointer) = std::forward<T>(first);
+
+        if constexpr (sizeof...(rest) == 0) {
+            return reinterpret_cast<T*>(pointer);
+        } else {
+            return stack_push(reinterpret_cast<void*>(pointer), std::forward<Ts>(rest)...);
+        }
+    }
+
+    static inline auto** self_on_coro_stack(void* stack) noexcept {
+        return reinterpret_cast<agbabi_coro_t**>(reinterpret_cast<std::uintptr_t>(stack) & ~0x7) - 2;
+    }
+
+} // namespace gba::agbabi::detail
+
+#endif // define GBAXX_EXT_AGBABI_DETAIL_STACK_HPP

--- a/include/gba/ext/agbabi/fiber.hpp
+++ b/include/gba/ext/agbabi/fiber.hpp
@@ -10,95 +10,83 @@
 #ifndef GBAXX_EXT_AGBABI_FIBER_HPP
 #define GBAXX_EXT_AGBABI_FIBER_HPP
 
-#include <array>
-#include <concepts>
-#include <functional>
-#include <memory>
-#include <type_traits>
+#include <utility>
 
 #include <agbabi.h>
 
-#include <gba/util/array_traits.hpp>
+#include <gba/ext/agbabi/detail/coro_context.hpp>
+#include <gba/ext/agbabi/detail/stack.hpp>
 
 namespace gba::agbabi {
-namespace detail {
 
-    template <class T>
-    concept PointerEnd = requires(T& a) {
-        { std::end(a) } -> std::same_as<util::array_value_type<T>*>;
-    };
+class fiber {
+private:
+    using context_type = detail::context_type<void>;
+    using coro_type = detail::coro_type<void>;
 
-    template <class Type, typename... Args>
-    auto* stack_emplace(std::ptrdiff_t& stackEnd, Args... args) noexcept {
-        stackEnd -= sizeof(Type);
-        stackEnd &= ~0x3;
-        return std::construct_at<Type>(reinterpret_cast<Type*>(stackEnd), std::forward<Args>(args)...);
-    }
+    explicit fiber(context_type* ctx) noexcept : m_ctx{ctx} {}
 
-    template <typename Type>
-    auto* stack_put(std::ptrdiff_t& stackEnd, const Type& type) noexcept {
-        stackEnd -= sizeof(type);
-        stackEnd &= ~0x3;
-        return std::construct_at<Type>(reinterpret_cast<Type*>(stackEnd), type);
-    }
+    template <typename Fn>
+    struct callable_context_type : context_type {
+        explicit callable_context_type(Fn&& fn) noexcept : m_fn{fn} {}
 
-} // namespace detail
+        ~callable_context_type() noexcept override = default;
 
-class fiber : public agbabi_coro_t {
-public:
-    class yield_type {
-        friend fiber;
-    public:
-        explicit yield_type(agbabi_coro_t* owner) noexcept : m_owner{owner} {}
+        void swap() noexcept override {
+            __agbabi_coro_resume(coro);
+        }
 
-        void operator()() noexcept {
-            m_hasYielded = true;
-            __agbabi_coro_yield(m_owner, 0);
+        static auto get_invoke() noexcept {
+            using proc_type = int(*)(agbabi_coro_t*);
+            return reinterpret_cast<proc_type>(+[](coro_type* coro) {
+                auto* ctx = reinterpret_cast<callable_context_type*>(coro->ctx);
+                auto y = detail::yield_context_type{coro};
+                auto f = fiber(&y);
+                ctx->m_fn(f);
+                return 0;
+            });
         }
     private:
-        yield_type(yield_type&& other) noexcept : m_owner{other.m_owner}, m_hasYielded{other.m_hasYielded} {
-            other.m_owner = nullptr;
-        }
-
-        agbabi_coro_t* m_owner{};
-        bool m_hasYielded{false};
+        Fn m_fn;
     };
 
-    using function_type = std::function<void(yield_type&)>;
+    template <typename Fn>
+    auto* make_context(void* sp, Fn&& fn) noexcept {
+        auto* coro = detail::stack_emplace<coro_type>(sp);
+        auto* ctx = detail::stack_emplace<callable_context_type<Fn>>(coro, std::forward<Fn>(fn));
+        __agbabi_coro_make(coro, ctx, callable_context_type<Fn>::get_invoke());
 
-    template <class Stack> requires detail::PointerEnd<Stack>
-    fiber(Stack& stack, function_type&& function) noexcept : agbabi_coro_t{} {
-        auto stackEnd = reinterpret_cast<std::ptrdiff_t>(std::end(stack));
-        m_yield = detail::stack_emplace<yield_type>(stackEnd, this);
-        m_function = detail::stack_put(stackEnd, function);
-        __agbabi_coro_make(this, reinterpret_cast<void*>(stackEnd), invoke);
+        coro->ctx = ctx;
+        ctx->coro = coro;
+        return ctx;
     }
 
-    fiber(fiber&& other) noexcept : agbabi_coro_t{other.arm_sp, other.joined}, m_yield{other.m_yield}, m_function{other.m_function} {
-        other.arm_sp = other.joined = 0;
-        other.m_yield = nullptr;
-        other.m_function = nullptr;
-        m_yield->m_owner = this;
+    context_type* m_ctx;
+public:
+    template <typename Fn>
+    fiber(detail::PointerEnd auto& stack, Fn&& fn) noexcept : m_ctx{make_context(std::end(stack), std::forward<Fn>(fn))} {
+    }
+
+    fiber(const fiber&) = delete;
+    fiber& operator=(const fiber&) = delete;
+
+    fiber(fiber&& other) noexcept : m_ctx{} {
+        std::swap(m_ctx, other.m_ctx);
+    }
+
+    auto& operator=(fiber&& other) noexcept {
+        std::swap(m_ctx, other.m_ctx);
+        return *this;
     }
 
     void operator()() noexcept {
-        m_yield->m_hasYielded = false;
-        __agbabi_coro_resume(this);
+        m_ctx->swap();
     }
 
     [[nodiscard]]
-    explicit operator auto() const noexcept {
-        return m_yield->m_hasYielded;
+    explicit operator bool() const noexcept {
+        return m_ctx && !m_ctx->coro->joined;
     }
-private:
-    static int invoke(agbabi_coro_t* self) noexcept {
-        auto* f = reinterpret_cast<fiber*>(self);
-        std::invoke(*f->m_function, *f->m_yield);
-        return 0;
-    }
-
-    yield_type* m_yield{};
-    function_type* m_function{};
 };
 
 } // namespace gba::agbabi


### PR DESCRIPTION
Fixes a crash when moving coroutines, simplifies implementation (removes use of `std::function`), and supports C++20 ranges

```c++
auto fibonacci = coroutine<int>::pull_type(stack, [](auto& yield){
    auto first = 1, second = 1;
    yield(first);
    yield(second);
    while (true) {
        const auto third = first + second;
        first = second;
        second = third;
        yield(third);
    }
});

// Take the first 10 Fibonacci numbers
for (auto i : fibonacci | std::ranges::views::take(10)) {
    // ...
}
```

Because it's now closer to Boost coroutine2, the yield type is now the corresponding coroutine, so the yield type of `pull` is `push`, and yield type of `push` is `pull`. Yield type of `fiber` is `fiber`.