### PR TITLE
Very basic debug printing

### DIFF
--- a/include/gba/ext/log.hpp
+++ b/include/gba/ext/log.hpp
@@ -1,0 +1,76 @@
+/*
+===============================================================================
+
+ Copyright (C) 2022 gba-hpp contributors
+ For conditions of distribution and use, see copyright notice in LICENSE.md
+
+===============================================================================
+*/
+
+#ifndef GBAXX_EXT_LOG_HPP
+#define GBAXX_EXT_LOG_HPP
+
+#include <initializer_list>
+#include <string_view>
+#include <utility>
+
+#include <gba/ext/log/detail.hpp>
+
+namespace gba::log {
+namespace {
+
+    [[maybe_unused]]
+    constexpr auto mgba = detail::interface{
+        detail::interface_mgba::init,
+        detail::interface_mgba::puts,
+        detail::interface_mgba::flush
+    };
+
+    [[maybe_unused]]
+    constexpr auto nocash = detail::interface{
+        detail::interface_nocash::init,
+        detail::interface_nocash::puts,
+        detail::interface_nocash::flush
+    };
+
+    [[maybe_unused]]
+    constexpr auto none = detail::interface{
+        detail::interface_none::init,
+        detail::interface_none::puts,
+        detail::interface_none::flush
+    };
+
+}
+
+namespace detail {
+
+    [[gnu::section(".ewram.data.gbaxx_log_detail_current_interface")]]
+    static constinit const interface* current_interface = &none;
+
+} // namespace detail
+
+template <typename... T>
+bool init(auto&& _, T&&... interfaces) noexcept {
+    if (_.init()) {
+        detail::current_interface = &_;
+        return true;
+    }
+
+    if constexpr (sizeof...(T) > 0) {
+        return init(std::forward<T>(interfaces)...);
+    } else {
+        return false;
+    }
+}
+
+namespace {
+
+void print(level level, std::string_view text) noexcept {
+    detail::current_interface->puts(0, text);
+    detail::current_interface->flush(level);
+}
+
+} // namespace
+} // namespace gba::log
+
+#endif // define GBAXX_EXT_LOG_HPP

--- a/include/gba/ext/log/detail.hpp
+++ b/include/gba/ext/log/detail.hpp
@@ -1,0 +1,113 @@
+/*
+===============================================================================
+
+ Copyright (C) 2022 gba-hpp contributors
+ For conditions of distribution and use, see copyright notice in LICENSE.md
+
+===============================================================================
+*/
+
+#ifndef GBAXX_EXT_LOG_DETAIL_HPP
+#define GBAXX_EXT_LOG_DETAIL_HPP
+
+#include <algorithm>
+#include <string>
+#include <string_view>
+#include <type_traits>
+
+#if defined GBAXX_HAS_AGBABI
+#include <aeabi.h>
+#endif
+
+#include <gba/inttype.hpp>
+#include <gba/ioregister.hpp>
+
+#include <gba/bios/swi_call.hpp>
+
+#include <gba/registers/system.hpp>
+
+#include <gba/util/byte_array.hpp>
+
+namespace gba::log {
+
+enum class level : int {
+    fatal = 0,
+    error = 1,
+    warn = 2,
+    info = 3,
+    debug = 4,
+    trace = 5
+};
+
+namespace detail {
+
+struct interface {
+    bool (*init)();
+    std::size_t (*puts)(std::size_t begin, std::string_view text);
+    void (*flush)(log::level level);
+};
+
+struct interface_none {
+    static bool init() noexcept {
+        return true;
+    }
+
+    static std::size_t puts([[maybe_unused]] std::size_t begin, [[maybe_unused]] std::string_view text) noexcept {
+        return 0u;
+    }
+
+    static void flush([[maybe_unused]] level level) noexcept {}
+};
+
+struct interface_mgba {
+    static constexpr auto code = uint16{0xC0DE};
+    static constexpr auto idea = uint16{0x1DEA};
+
+    [[nodiscard]]
+    static bool init() noexcept {
+        io::register_emplace<uint16, 0x04FFF780>(code);
+        return io::register_read<uint16, 0x04FFF780>() == idea;
+    }
+
+    static std::size_t puts(std::size_t begin, std::string_view text) noexcept {
+        const auto len = std::min(256u - begin, text.size());
+#if defined GBAXX_HAS_AGBABI
+        __aeabi_memcpy(reinterpret_cast<char*>(0x04FFF600) + begin, text.cbegin(), len);
+#else
+        std::memcpy(reinterpret_cast<char*>(0x04FFF600) + begin, text.cbegin(), len);
+#endif
+        return len;
+    }
+
+    static void flush(level level) noexcept {
+        using underlying_type = std::underlying_type_t<log::level>;
+
+        io::register_emplace<uint16, 0x04FFF700>(static_cast<uint16>(static_cast<underlying_type>(level) | 0x100));
+    }
+};
+
+struct interface_nocash {
+    static constexpr auto nocashgba = util::to_char_array("no$gba");
+
+    [[nodiscard]]
+    static bool init() noexcept {
+        const auto signature = *reinterpret_cast<std::array<char, 6>*>(0x04FFFA00);
+        return signature == nocashgba;
+    }
+
+    static std::size_t puts([[maybe_unused]] std::size_t begin, std::string_view text) noexcept {
+        for (auto c: text) {
+            io::register_emplace<char, 0x04FFFA1C>(c);
+        }
+        return text.size();
+    }
+
+    static void flush([[maybe_unused]] level level) noexcept {
+        io::register_emplace<char, 0x04FFFA1C>('\n');
+    }
+};
+
+} // namespace detail
+} // namespace gba::log
+
+#endif // define GBAXX_EXT_LOG_DETAIL_HPP

--- a/include/gba/gba.hpp
+++ b/include/gba/gba.hpp
@@ -51,6 +51,7 @@
 #include <gba/bios/swi_call.hpp>
 
 #include <gba/ext/agbabi.hpp>
+#include <gba/ext/log.hpp>
 
 #include <gba/interrupt/handler.hpp>
 

--- a/include/gba/ioregister.hpp
+++ b/include/gba/ioregister.hpp
@@ -42,11 +42,11 @@ inline void register_write(const Type& value) noexcept {
 template <class Type, std::uintptr_t Address, typename... Args>
 inline void register_emplace(Args&&... args) noexcept {
     if constexpr (std::is_fundamental_v<Type> || std::is_pointer_v<Type>) {
-        *reinterpret_cast<volatile Type*>(Address) = Type{args...};
+        *reinterpret_cast<volatile Type*>(Address) = Type{std::forward<Args>(args)...};
     } else if constexpr (std::is_constructible_v<Type, Args...>) {
-        reinterpret_cast<volatile util::bit_container<Type>*>(Address)->copy_from(util::bit_container<Type>::construct(args...));
+        reinterpret_cast<volatile util::bit_container<Type>*>(Address)->copy_from(util::bit_container<Type>::construct(std::forward<Args>(args)...));
     } else if constexpr (std::is_trivially_copyable_v<Type>) {
-        reinterpret_cast<volatile util::bit_container<Type>*>(Address)->copy_from(util::bit_container<Type>{Type{args...}});
+        reinterpret_cast<volatile util::bit_container<Type>*>(Address)->copy_from(util::bit_container<Type>{Type{std::forward<Args>(args)...}});
     } else {
         static_assert(util::always_false<Type>);
     }

--- a/include/gba/registers/system_types.hpp
+++ b/include/gba/registers/system_types.hpp
@@ -67,6 +67,10 @@ namespace waitcnt {
 
     static constexpr auto prefetch = field_of::boolean<waitcnt_type, 14>();
 
+    static constexpr auto phi(phi i) noexcept {
+        return field_of::enum_class<waitcnt_type, 11, gba::phi, phi::div_1>(i);
+    }
+
 } // namespace waitcnt
 
 namespace undocumented {

--- a/include/gba/util/byte_array.hpp
+++ b/include/gba/util/byte_array.hpp
@@ -19,17 +19,32 @@
 
 namespace gba::util {
 
-template <class T>
+template <typename T>
 concept IntegerArray = requires {
     requires Array<T>;
     requires std::is_integral_v<array_value_type<T>>;
 };
 
-template <class T>
+template <typename T>
 concept ByteArray = requires {
     requires Array<T>;
     requires std::is_same_v<std::byte, array_value_type<T>>;
 };
+
+template <typename T>
+concept StringLiteral = std::is_same_v<T,
+        std::add_lvalue_reference_t<
+            const char[std::extent_v<std::remove_reference_t<T>>]
+        >
+    >;
+
+consteval auto to_char_array(StringLiteral auto&& data) noexcept {
+    constexpr auto size = array_size<decltype(data)> - 1u;
+
+    std::array<char, size> result{};
+    std::copy_n(std::cbegin(data), size, std::begin(result));
+    return result;
+}
 
 consteval ByteArray auto to_byte_array(const IntegerArray auto& data) noexcept {
     using value_type = array_value_type<decltype(data)>;


### PR DESCRIPTION
I think anything beyond this would need a string formatting library, and I'm not quite prepared to do that for the GBA just yet
```cpp
#include <gba/gba.hpp>

int main() {
    using namespace gba;

    log::init(log::mgba, log::nocash); // Try initialising logging for mGBA, and then no$gba
    log::print(log::level::info, "Hello, World!"); // Print "Hello, World!"
}
```
I've got my eyes on AGBPrint, but the source code out there is a bit funky, so I think I need to understand that API a bit better.