### PR TITLE
add meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,9 @@
+project('gba-hpp', 'cpp',
+  version: '4.0.0',
+  license: 'Zlib',
+  default_options: ['warning_level=2', 'cpp_std=c++20'])
+
+gba_hpp_dep = declare_dependency(
+  include_directories: ['include'])
+
+meson.override_dependency('gba-hpp', gba_hpp_dep)


### PR DESCRIPTION
To use in downstream projects, clone `gba-hpp` into your meson project's `subprojects` directory.

In your main meson.build, call `subproject('gba-hpp')`, and add `dependency('gba-hpp')` to build targets.

See <https://github.com/LunarLambda/meson-gba-toolchain> for more information.